### PR TITLE
fix: adding sonar.login also to dotnet-sonarscanner end exec

### DIFF
--- a/src/main/kotlin/com/itiviti/tasks/DotnetSonarTask.kt
+++ b/src/main/kotlin/com/itiviti/tasks/DotnetSonarTask.kt
@@ -1,11 +1,18 @@
 package com.itiviti.tasks
 
+import com.itiviti.DotnetSonarPlugin
 import com.itiviti.extensions.DotnetSonarExtension
 import org.gradle.api.tasks.Exec
 
 open class DotnetSonarTask: Exec() {
     init {
         commandLine(project.buildDir.resolve(DotnetSonarExtension.toolPath).resolve("dotnet-sonarscanner"))
+
+        val extension = project.extensions.getByType(DotnetSonarPlugin::class.java)
+        val props = extension.computeSonarProperties(project)
+        val endProps = props.filter { it.key == "sonar.login" }
+        extension.buildArgs(endProps).forEach { args(it) }
+
         args("end")
     }
 }


### PR DESCRIPTION
I made some changes that potentially could (!) resolve the login issue #2 that I opened yesterday.

However, I am usually using Java, so I am really not a kotlin expert (yet).
Furthermore, I am sure that you could implement that in a better way when it comes to software architecture (I just reused the methods in the SonarPlugin class, but I also had to make them public...)

Due to some time restrictions I also did not test that code at all (!!!).
I would still be very interested in your feedback and hope that this PR helps and eases your work a bit :-)

Cheers,
Niko