### PR TITLE
Fix dotnet preview version parsing

### DIFF
--- a/src/main/kotlin/com/itiviti/DotnetPlugin.kt
+++ b/src/main/kotlin/com/itiviti/DotnetPlugin.kt
@@ -38,7 +38,7 @@ class DotnetPlugin: Plugin<Project> {
             }.exitValue
         }
 
-        private fun getMajorVersion(version: String) = version.substringBeforeLast('.').toDouble()
+        private fun getMajorVersion(version: String) = version.substringBeforeLast('-', version).substringBeforeLast('.').toDouble()
 
         fun listSdks(project: Project, extension: DotnetPluginExtension): String {
             val listSdksOutputStream = ByteArrayOutputStream()


### PR DESCRIPTION
Currently parsing output of `dotnet --version` fails with preview versions of VS/dotnet as version string has another format, `6.0.400-preview.22301.10` instead of expected `6.0.400`