### PR TITLE
Ignore vulnerable package warnings

### DIFF
--- a/src/main/resources/com/itiviti/parser/ProjectFileParser.csproj
+++ b/src/main/resources/com/itiviti/parser/ProjectFileParser.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="'$(FrameworkVersion)'==''">netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- The Microsoft.Build contains as transitive dependency the
System.Drawing.Common 4.7.0 package, which contains a vulnerability
which causes the jenkins jobs that use this plugin to fail

Issue: UNLN-772