### PR TITLE
DotnetTest compatible with configurationCache

### DIFF
--- a/src/main/kotlin/com/itiviti/DotnetPlugin.kt
+++ b/src/main/kotlin/com/itiviti/DotnetPlugin.kt
@@ -14,7 +14,6 @@ import org.reflections.Reflections
 import org.reflections.scanners.ResourcesScanner
 import org.reflections.util.ClasspathHelper
 import org.reflections.util.ConfigurationBuilder
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -251,6 +250,7 @@ class DotnetPlugin: Plugin<Project> {
                 group = TASK_GROUP
                 description = ".NET test driver used to execute unit tests."
                 mustRunAfter(dotnetBuild)
+                filter.convention(testExtension.filter)
             }
         }
         project.tasks.named(LifecycleBasePlugin.BUILD_TASK_NAME).configure {

--- a/src/main/kotlin/com/itiviti/extensions/DotnetTestExtension.kt
+++ b/src/main/kotlin/com/itiviti/extensions/DotnetTestExtension.kt
@@ -1,16 +1,17 @@
 package com.itiviti.extensions
 
+import org.gradle.api.provider.Property
 import java.io.File
 
 /**
  * https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test
  */
-open class DotnetTestExtension(buildDir: File) {
+abstract class DotnetTestExtension(buildDir: File) {
     /**
      * Filters out tests in the current project using the given expression.
      * http://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/
      */
-    var filter: String? = null
+    abstract val filter: Property<String>
 
     /**
      * The .runsettings file to use for running the tests

--- a/src/main/kotlin/com/itiviti/tasks/DotnetTestTask.kt
+++ b/src/main/kotlin/com/itiviti/tasks/DotnetTestTask.kt
@@ -3,16 +3,19 @@ package com.itiviti.tasks
 import com.itiviti.extensions.DotnetNUnitExtension
 import com.itiviti.extensions.DotnetTestExtension
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 
-open class DotnetTestTask: DotnetBaseTask("test") {
-    private var filter: String? = null
+abstract class DotnetTestTask: DotnetBaseTask("test") {
 
-    @Option(option = "dotnet-tests", description = "Override filter options")
-    fun setFilter(filter: String?) {
-        this.filter = filter
-    }
+    @get:Input
+    @get:Optional
+    @get:Option(option = "dotnet-tests", description = "Override filter options")
+    abstract val filter: Property<String>
+
 
     init {
         // built with DotnetBuildTask
@@ -55,13 +58,8 @@ open class DotnetTestTask: DotnetBaseTask("test") {
 
     @TaskAction
     override fun exec() {
-        // Override filter when set
-        val testExtension = (getPluginExtension() as ExtensionAware).extensions.getByType(DotnetTestExtension::class.java)
-        if (!filter.isNullOrBlank()) {
-            args = (listOf(args!![0], "--filter", filter)) + args!!.drop(1)
-        }
-        else if (!testExtension.filter.isNullOrBlank()) {
-            args = (listOf(args!![0], "--filter", testExtension.filter)) + args!!.drop(1)
+        if (!filter.orNull.isNullOrBlank()){
+            args = (listOf(args!![0], "--filter", filter.get())) + args!!.drop(1)
         }
 
         super.exec()


### PR DESCRIPTION
The way dotnetTest is currently implemented is not compatible with ConfigurationCache, which is the default mode of execution in gradle 9.

This pr fixes this