### PR TITLE
Fixes a few things about the version

### DIFF
--- a/src/main/kotlin/com/itiviti/DotnetPlugin.kt
+++ b/src/main/kotlin/com/itiviti/DotnetPlugin.kt
@@ -145,7 +145,7 @@ class DotnetPlugin: Plugin<Project> {
             if (buildExtension.version.get().isNotEmpty()) {
                 args["Version"] = buildExtension.version.get()
             }
-            if (buildExtension.version.get().isNotEmpty()) {
+            if (buildExtension.packageVersion.get().isNotEmpty()) {
                 args["PackageVersion"] = buildExtension.packageVersion.get()
             }
 

--- a/src/main/kotlin/com/itiviti/DotnetPlugin.kt
+++ b/src/main/kotlin/com/itiviti/DotnetPlugin.kt
@@ -142,11 +142,11 @@ class DotnetPlugin: Plugin<Project> {
             if (!extension.platform.isNullOrBlank()) {
                 args["Platform"] = extension.platform!!
             }
-            if (buildExtension.version.isNotEmpty()) {
-                args["Version"] = buildExtension.version
+            if (buildExtension.version.get().isNotEmpty()) {
+                args["Version"] = buildExtension.version.get()
             }
-            if (buildExtension.packageVersion.isNotEmpty()) {
-                args["PackageVersion"] = buildExtension.packageVersion
+            if (buildExtension.version.get().isNotEmpty()) {
+                args["PackageVersion"] = buildExtension.packageVersion.get()
             }
 
             val parser = project.providers.exec { exec ->
@@ -201,7 +201,10 @@ class DotnetPlugin: Plugin<Project> {
         val extension = project.extensions.create("dotnet", DotnetPluginExtension::class.java, project.name, project.projectDir, { evaluateProject(project) })
         val extensionAware = extension as ExtensionAware
         extensionAware.extensions.create("restore", DotnetRestoreExtension::class.java)
-        extensionAware.extensions.create("build", DotnetBuildExtension::class.java, project.version)
+        val buildExtension = extensionAware.extensions.create("build", DotnetBuildExtension::class.java)
+        buildExtension.version.convention(project.provider { project.version.toString() })
+        buildExtension.packageVersion.convention(project.provider { project.version.toString() })
+
         val testExtension = extensionAware.extensions.create("test", DotnetTestExtension::class.java, project.layout.buildDirectory.get().asFile)
         (testExtension as ExtensionAware).extensions.create("nunit", DotnetNUnitExtension::class.java, project.layout.buildDirectory.get().asFile)
         extensionAware.extensions.create("nugetPush", DotnetNugetPushExtension::class.java)

--- a/src/main/kotlin/com/itiviti/extensions/DotnetBuildExtension.kt
+++ b/src/main/kotlin/com/itiviti/extensions/DotnetBuildExtension.kt
@@ -4,13 +4,14 @@ import groovy.lang.GroovyObjectSupport
 import groovy.lang.MissingPropertyException
 import groovy.lang.ReadOnlyPropertyException
 import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.provider.Property
 import org.gradle.process.ExecSpec
 
-open class DotnetBuildExtension(projectVersion: String) : GroovyObjectSupport() {
+abstract class DotnetBuildExtension : GroovyObjectSupport() {
     private val storage = mutableMapOf<String, Any?>()
 
-    var version = projectVersion
-    var packageVersion = projectVersion
+    abstract val version : Property<String>;
+    abstract val packageVersion: Property<String>;
 
     operator fun get(property: String): String? {
         return storage[property]?.toString()

--- a/src/main/kotlin/com/itiviti/tasks/DotnetBuildTask.kt
+++ b/src/main/kotlin/com/itiviti/tasks/DotnetBuildTask.kt
@@ -3,7 +3,10 @@ package com.itiviti.tasks
 import com.itiviti.extensions.DotnetBuildExtension
 import com.itiviti.extensions.DotnetRestoreExtension
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.process.ExecSpec
 import java.io.File
@@ -24,6 +27,13 @@ open class DotnetBuildTask: DotnetBaseTask("build") {
             buildExtension.addCustomBuildProperties(exec)
         }
     }
+    @Input
+    @Optional
+    val version: Property<String> = project.objects.property(String::class.java).convention(getNestedExtension(DotnetBuildExtension::class.java).version)
+
+    @Input
+    @Optional
+    val packageVersion: Property<String> = project.objects.property(String::class.java).convention(getNestedExtension(DotnetBuildExtension::class.java).packageVersion)
 
     @InputFiles
     val sources: ListProperty<File> = project.objects.listProperty(File::class.java)
@@ -32,6 +42,8 @@ open class DotnetBuildTask: DotnetBaseTask("build") {
     @OutputDirectories
     val destinations: ListProperty<File> = project.objects.listProperty(File::class.java)
             .convention (project.provider { getPluginExtension().allProjects.map { it.value.getOutputPaths() }.flatten() })
+
+
 
     init {
         sources.finalizeValueOnRead()
@@ -49,11 +61,11 @@ open class DotnetBuildTask: DotnetBaseTask("build") {
             args("--no-restore")
         }
 
-        if (buildExtension.version.isNotEmpty()) {
-            args("-p:Version=${buildExtension.version}")
+        if (!version.orNull.isNullOrBlank()) {
+            args("-p:Version=${version.get()}")
         }
-        if (buildExtension.packageVersion.isNotEmpty()) {
-            args("-p:PackageVersion=${buildExtension.packageVersion}")
+        if (!packageVersion.orNull.isNullOrBlank()) {
+            args("-p:PackageVersion=${packageVersion.get()}")
         }
 
         buildExtension.addCustomBuildProperties(this)


### PR DESCRIPTION
This PR adresses the following problems:

1. The version/packageVersion are supposed to default to the gradle version. But the way its currently implemented it only works if the version is set before applying the plugin  so this 'works' ( edit: no thats actually also not working without this PR)
```
version = '1'
plugins {
    id 'com.itiviti.dotnet'
}
```
Upon rechecking this also doesnt seem to work... it seems to only work if a different plugin sets the version...
But this didn't
```
plugins {
    id 'com.itiviti.dotnet'
}
version = '1'
```
2. If you change the version, gradle would claim dotnetBuild is upToDate and not rebuild it

I am also not so sure about these empty checks on the version, because in gradle if you dont specify a version the version becomes 'unspecified' and not empty..
